### PR TITLE
Use MySqlConnector

### DIFF
--- a/src/Identity.Dapper.MySQL/Identity.Dapper.MySQL.csproj
+++ b/src/Identity.Dapper.MySQL/Identity.Dapper.MySQL.csproj
@@ -25,7 +25,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MySql.Data" Version="8.0.8-dmr" />
+    <PackageReference Include="MySqlConnector" Version="0.35.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Identity.Dapper/Stores/DapperUserStore.cs
+++ b/src/Identity.Dapper/Stores/DapperUserStore.cs
@@ -36,8 +36,6 @@ namespace Identity.Dapper.Stores
         where TUserLogin : DapperIdentityUserLogin<TKey>
         where TRole : DapperIdentityRole<TKey, TUserRole, TRoleClaim>
     {
-        private DbConnection _connection;
-
         private readonly IUnitOfWork _unitOfWork;
         private readonly IConnectionProvider _connectionProvider;
         private readonly ILogger<DapperUserStore<TUser, TKey, TUserRole, TRoleClaim, TUserClaim, TUserLogin, TRole>> _log;
@@ -54,22 +52,6 @@ namespace Identity.Dapper.Stores
             _log = log;
             _unitOfWork = uow;
             _dapperIdentityOptions = dapperIdOpts;
-        }
-
-        private async Task CreateTransactionIfNotExistsAsync(CancellationToken cancellationToken)
-        {
-            if (!_dapperIdentityOptions.UseTransactionalBehavior)
-            {
-                _connection = _connectionProvider.Create();
-                await _connection.OpenAsync(cancellationToken);
-            }
-            else
-            {
-                _connection = _unitOfWork.CreateOrGetConnection();
-
-                if (_connection.State == System.Data.ConnectionState.Closed)
-                    await _connection.OpenAsync(cancellationToken);
-            }
         }
 
         public Task SaveChangesAsync(CancellationToken cancellationToken = default(CancellationToken)) =>
@@ -117,7 +99,6 @@ namespace Identity.Dapper.Stores
         public async Task AddClaimsAsync(TUser user, IEnumerable<Claim> claims, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await CreateTransactionIfNotExistsAsync(cancellationToken);
 
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
@@ -135,7 +116,6 @@ namespace Identity.Dapper.Stores
         public async Task AddLoginAsync(TUser user, UserLoginInfo login, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await CreateTransactionIfNotExistsAsync(cancellationToken);
 
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
@@ -153,7 +133,6 @@ namespace Identity.Dapper.Stores
         public async Task AddToRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await CreateTransactionIfNotExistsAsync(cancellationToken);
 
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
@@ -171,7 +150,6 @@ namespace Identity.Dapper.Stores
         public async Task<IdentityResult> CreateAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await CreateTransactionIfNotExistsAsync(cancellationToken);
 
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
@@ -205,7 +183,6 @@ namespace Identity.Dapper.Stores
         public async Task<IdentityResult> DeleteAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await CreateTransactionIfNotExistsAsync(cancellationToken);
 
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
@@ -603,7 +580,6 @@ namespace Identity.Dapper.Stores
         public async Task RemoveClaimsAsync(TUser user, IEnumerable<Claim> claims, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await CreateTransactionIfNotExistsAsync(cancellationToken);
 
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
@@ -624,7 +600,6 @@ namespace Identity.Dapper.Stores
         public async Task RemoveFromRoleAsync(TUser user, string roleName, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await CreateTransactionIfNotExistsAsync(cancellationToken);
 
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
@@ -645,7 +620,6 @@ namespace Identity.Dapper.Stores
         public async Task RemoveLoginAsync(TUser user, string loginProvider, string providerKey, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await CreateTransactionIfNotExistsAsync(cancellationToken);
 
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
@@ -674,7 +648,6 @@ namespace Identity.Dapper.Stores
         public async Task ReplaceClaimAsync(TUser user, Claim claim, Claim newClaim, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await CreateTransactionIfNotExistsAsync(cancellationToken);
 
             if (user == null)
                 throw new ArgumentNullException(nameof(user));
@@ -855,7 +828,6 @@ namespace Identity.Dapper.Stores
         public async Task<IdentityResult> UpdateAsync(TUser user, CancellationToken cancellationToken)
         {
             cancellationToken.ThrowIfCancellationRequested();
-            await CreateTransactionIfNotExistsAsync(cancellationToken);
 
             if (user == null)
                 throw new ArgumentNullException(nameof(user));

--- a/test/Identity.Dapper.Tests.Integration/integrationtest.config.mysql.json
+++ b/test/Identity.Dapper.Tests.Integration/integrationtest.config.mysql.json
@@ -1,6 +1,6 @@
 ﻿{
   "DapperIdentity": {
-    "ConnectionString": "Server=127.0.0.1;Database=identity;",
+    "ConnectionString": "Server=127.0.0.1;Database=identity;UseAffectedRows=false;",
     "Username": "identity",
     "Password": "123456"
   }


### PR DESCRIPTION
Fixes #62.

I tested locally with `dotnet test -c Release --filter="FullyQualifiedName~Identity.Dapper.Tests.Integration.MySQL"`. (The `docker-compose` setup described in the repo made testing very easy—thanks!)

This PR also removes a connection leak (that I observed when checking MySqlConnector logs); this could cause performance problems if the connections were being leaked faster than the connection pool was reclaiming them.

I added a simple (read-only) benchmark and ran it before and after the MySqlConnector change (I included the connection leak change when benchmarking MySql.Data): https://github.com/mysql-net/Identity.Dapper/commit/517ffefd50da395b663dbbabe79ecbd5fd4c989c

```
BenchmarkDotNet=v0.10.12, OS=Windows 10 Redstone 3 [1709, Fall Creators Update] (10.0.16299.192)
Intel Xeon CPU E5-1650 v3 3.50GHz, 1 CPU, 12 logical cores and 6 physical cores
Frequency=3410072 Hz, Resolution=293.2489 ns, Timer=TSC
.NET Core SDK=2.1.4
  [Host]     : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
  DefaultJob : .NET Core 2.0.5 (Framework 4.6.26020.03), 64bit RyuJIT
```

### MySql.Data

Method | Mean | Error | StdDev
--- | --- | --- | ---
FindUserByName | 1.615 ms | 0.0315 ms | 0.0481 ms |
GetClaims | 3.173 ms | 0.0625 ms | 0.1449 ms |
ChangeEmail | 5.094 ms | 0.1014 ms | 0.1775 ms |
ChangePhoneNumber | 4.833 ms | 0.0961 ms | 0.2742 ms |

### MySqlConnector

Method | Mean | Error | StdDev
--- | --- | --- | ---
FindUserByName | 1.563 ms | 0.0309 ms | 0.0770 ms |
GetClaims | 3.104 ms | 0.0611 ms | 0.0895 ms |
ChangeEmail | 5.037 ms | 0.0998 ms | 0.1263 ms |
ChangePhoneNumber | 4.979 ms | 0.0895 ms | 0.1926 ms |

These results are very close; it looks like MySqlConnector could be slightly faster, although the difference is usually within the measured experimental error.

However, MySql.Data doesn't reset the connection by default, so you may hit [MySQL bug 77421](https://bugs.mysql.com/bug.php?id=77421). This also means that MySqlConnector is doing extra work. If we enable `ConnectionReset=true` in the MySql.Data connection string (to get equivalent behaviour), we get the following timings for MySql.Data; now MySqlConnector is clearly 5‒6× faster.

Method | Mean | Error | StdDev
--- | --- | --- | ---
FindUserByName |  8.704 ms | 0.1701 ms | 0.2698 ms |
GetClaims | 17.944 ms | 0.3524 ms | 0.4457 ms |
ChangeEmail | 26.620 ms | 0.5515 ms | 0.9513 ms |
ChangePhoneNumber | 26.204 ms | 0.3112 ms | 0.2911 ms |
