### PR TITLE
EncryptionHelper TryDecryptAES256 throws exception 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,10 +11,18 @@ To configure the DBMS connection, you can add a **DapperIdentity** and a **Dappe
     "Password": "123"
 },
 "DapperIdentityCryptography": {
-    "Key": "base64 32 bits key",
-    "IV": "base64 16 bits key"
+    "Key": "Base64 32 bytes key",
+    "IV": "Base64 16 bytes key"
 }
 ```
+
+**Example:** 
+Key: "E546C8DF278CD5931069B522E695D4F2" (32 Bytes)
+Base64 Encoded Key: "RTU0NkM4REYyNzhDRDU5MzEwNjlCNTIyRTY5NUQ0RjI="
+
+IV: "SomeReallyCoolIV" (16 Bytes)
+Base64 Encoded IV: "U29tZVJlYWxseUNvb2xJVg=="
+
 
 Alternatively, you can use **ConnectionStrings** default section:
 
@@ -30,8 +38,8 @@ dotnet user-secrets set DapperIdentity:ConnectionString "Connection string of yo
 dotnet user-secrets set DapperIdentity:Password "123"
 dotnet user-secrets set DapperIdentity:Username "user"
 
-dotnet user-secrets set DapperIdentityCryptography:Key "base64 32 bits key"
-dotnet user-secrets set DapperIdentityCryptography:IV "base64 16 bits key"
+dotnet user-secrets set DapperIdentityCryptography:Key "base64 32 bytes key"
+dotnet user-secrets set DapperIdentityCryptography:IV "base64 16 bytes key"
 ```
 
 The **DapperIdentity:Password** can be encrypted with AES256 using the KEY and IV provided.

--- a/README.md
+++ b/README.md
@@ -16,13 +16,12 @@ To configure the DBMS connection, you can add a **DapperIdentity** and a **Dappe
 }
 ```
 
-**Example:** 
-Key: "E546C8DF278CD5931069B522E695D4F2" (32 Bytes)
+**Example:**  
+Key: "E546C8DF278CD5931069B522E695D4F2" (32 Bytes)  
 Base64 Encoded Key: "RTU0NkM4REYyNzhDRDU5MzEwNjlCNTIyRTY5NUQ0RjI="
 
-IV: "SomeReallyCoolIV" (16 Bytes)
+IV: "SomeReallyCoolIV" (16 Bytes)  
 Base64 Encoded IV: "U29tZVJlYWxseUNvb2xJVg=="
-
 
 Alternatively, you can use **ConnectionStrings** default section:
 
@@ -38,8 +37,8 @@ dotnet user-secrets set DapperIdentity:ConnectionString "Connection string of yo
 dotnet user-secrets set DapperIdentity:Password "123"
 dotnet user-secrets set DapperIdentity:Username "user"
 
-dotnet user-secrets set DapperIdentityCryptography:Key "base64 32 bytes key"
-dotnet user-secrets set DapperIdentityCryptography:IV "base64 16 bytes key"
+dotnet user-secrets set DapperIdentityCryptography:Key "Base64 32 bytes key"
+dotnet user-secrets set DapperIdentityCryptography:IV "Base64 16 bytes key"
 ```
 
 The **DapperIdentity:Password** can be encrypted with AES256 using the KEY and IV provided.

--- a/samples/Identity.Dapper.Samples.Web/appsettings.json
+++ b/samples/Identity.Dapper.Samples.Web/appsettings.json
@@ -13,7 +13,7 @@
     }
   },
   "DapperIdentityCryptography": {
-    "Key": "FrFE/VtQ5pfNhGYVnyf65Sa6j4h6ion3ItkAnqLsnBE=",
-    "IV": "Ig/YU0tgUqI1u2VzWH0plQ=="
+    "Key": "RTU0NkM4REYyNzhDRDU5MzEwNjlCNTIyRTY5NUQ0RjI=",
+    "IV": "U29tZVJlYWxseUNvb2xJVg=="
   }
 }

--- a/src/Identity.Dapper/Cryptography/EncryptionHelper.cs
+++ b/src/Identity.Dapper/Cryptography/EncryptionHelper.cs
@@ -21,6 +21,17 @@ namespace Identity.Dapper.Cryptography
             _log = log;
         }
 
+        public static string Base64Encode(string plainText)
+        {
+            var plainTextBytes = System.Text.Encoding.UTF8.GetBytes(plainText);
+            return System.Convert.ToBase64String(plainTextBytes);
+        }
+
+        public static byte[] Base64Decode(string base64EncodedData)
+        {
+            return System.Convert.FromBase64String(base64EncodedData);
+        }
+
         /// <summary>
         /// Tries to decrypt a AES256 encrypted string.
         /// If the string is not encrypted or if it can't be decrypted, return the original string.
@@ -66,8 +77,8 @@ namespace Identity.Dapper.Cryptography
 
         private string EncryptInput(string input)
         {
-            var key = System.Text.Encoding.UTF8.GetBytes(_aesKeys.Value.Key);
-            var iv = System.Text.Encoding.UTF8.GetBytes(_aesKeys.Value.IV);
+            var key = Base64Decode(_aesKeys.Value.Key);
+            var iv = Base64Decode(_aesKeys.Value.IV);
 
             using (var aes = Aes.Create())
             {
@@ -96,11 +107,11 @@ namespace Identity.Dapper.Cryptography
         private string DecryptInput(string input)
         {
             var fullCipher = Convert.FromBase64String(input);
-            var iv = System.Text.Encoding.UTF8.GetBytes(_aesKeys.Value.IV);
+            var iv = Base64Decode(_aesKeys.Value.IV);
             var cipher = new byte[fullCipher.Length - iv.Length];
 
             Buffer.BlockCopy(fullCipher, iv.Length, cipher, 0, fullCipher.Length - iv.Length);
-            var key = System.Text.Encoding.UTF8.GetBytes(_aesKeys.Value.Key);
+            var key = Base64Decode(_aesKeys.Value.Key);
 
             using (var aes = Aes.Create())
             {

--- a/src/Identity.Dapper/Cryptography/EncryptionHelper.cs
+++ b/src/Identity.Dapper/Cryptography/EncryptionHelper.cs
@@ -67,7 +67,7 @@ namespace Identity.Dapper.Cryptography
         private string EncryptInput(string input)
         {
             var key = System.Text.Encoding.UTF8.GetBytes(_aesKeys.Value.Key);
-            var iv = System.Text.Encoding.ASCII.GetBytes(_aesKeys.Value.IV);
+            var iv = System.Text.Encoding.UTF8.GetBytes(_aesKeys.Value.IV);
 
             using (var aes = Aes.Create())
             {
@@ -96,7 +96,7 @@ namespace Identity.Dapper.Cryptography
         private string DecryptInput(string input)
         {
             var fullCipher = Convert.FromBase64String(input);
-            var iv = System.Text.Encoding.ASCII.GetBytes(_aesKeys.Value.IV);
+            var iv = System.Text.Encoding.UTF8.GetBytes(_aesKeys.Value.IV);
             var cipher = new byte[fullCipher.Length - iv.Length];
 
             Buffer.BlockCopy(fullCipher, iv.Length, cipher, 0, fullCipher.Length - iv.Length);

--- a/test/Identity.Dapper.Tests/Encryption/EncryptDecryptTest.cs
+++ b/test/Identity.Dapper.Tests/Encryption/EncryptDecryptTest.cs
@@ -22,8 +22,8 @@ namespace Identity.Dapper.Tests.Encryption
 
             var aesKeys = new AESKeys
             {
-                Key = _key,
-                IV = _iv
+                Key = EncryptionHelper.Base64Encode(_key),
+                IV = EncryptionHelper.Base64Encode(_iv)
             };
             _mockKeys.Setup(x => x.Value).Returns(aesKeys);
         }

--- a/test/Identity.Dapper.Tests/Encryption/EncryptDecryptTest.cs
+++ b/test/Identity.Dapper.Tests/Encryption/EncryptDecryptTest.cs
@@ -1,0 +1,45 @@
+﻿using Identity.Dapper.Cryptography;
+using Identity.Dapper.Models;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Identity.Dapper.Tests.Encryption
+{
+    public class EncryptDecryptTest
+    {
+        private readonly string _key = "E546C8DF278CD5931069B522E695D4F2";  // 32 bytes key for AES256
+        private readonly string _iv = "SomeReallyCoolIV";                   // 16 bytes vector for AES256
+
+        private Mock<ILogger<EncryptionHelper>> _mockLogger;
+        private Mock<IOptions<AESKeys>> _mockKeys;
+
+        public EncryptDecryptTest()
+        {
+            _mockLogger = new Mock<ILogger<EncryptionHelper>>();
+            _mockKeys = new Mock<IOptions<AESKeys>>();
+
+            var aesKeys = new AESKeys
+            {
+                Key = _key,
+                IV = _iv
+            };
+            _mockKeys.Setup(x => x.Value).Returns(aesKeys);
+        }
+
+        [Fact]
+        public void EncryptTextThenDecrypt()
+        {
+            const string textToEncrypt = "I hope I come out whole!";
+            var eh = new EncryptionHelper(_mockKeys.Object, _mockLogger.Object);
+
+            string encrypted = eh.EncryptAES256(textToEncrypt);
+            string decrypted = eh.TryDecryptAES256(encrypted);
+
+            Assert.NotEqual(encrypted, decrypted);
+            Assert.Equal(textToEncrypt, decrypted);
+        }
+
+    }
+}


### PR DESCRIPTION
When trying to decrypt a string, the method throws the following exception "The input data is not a complete block." and returns the same input given (tested under .NET Core 2.0).
I noticed this when my logs where being flooded with errors on User registration. 

Log Entry Example:
`{"Level": "Error", "Timestamp": "2018-01-23T12:13:22.6762643+00:00", "Properties": {"ActionId": "28bbddb1-ff40-4880-af22-2a7ef7e6dabc", "ThreadId": 9, "RequestId": "0HLB1K4845IA8:00000001", "ActionName": "Fmp.Web.Controllers.API.AccountController.Register (Fmp.Web)", "Application": "FMP", "MachineName": "RD00155D8A52DB", "ProcessName": "dotnet", "RequestPath": "/api/v1.0/account/register", "SourceContext": "Identity.Dapper.Cryptography.EncryptionHelper"}, "MessageTemplate": "Specified padding mode is not valid for this algorithm."}`

I added a Test so you can see the behavior and a possible Fix using the same AES256 Algorithm.
Also, notice that I am not doing Base64 on the Key/IV. You are welcome to revert this.