### PR TITLE
Preserve connection string when username/password are not in settings

### DIFF
--- a/src/Identity.Dapper.MySQL/Connections/MySqlConnectionProvider.cs
+++ b/src/Identity.Dapper.MySQL/Connections/MySqlConnectionProvider.cs
@@ -26,17 +26,23 @@ namespace Identity.Dapper.MySQL.Connections
             if (string.IsNullOrEmpty(_connectionProviderOptions.Value?.ConnectionString))
                 throw new ArgumentNullException("There's no DapperIdentity:ConnectionString configured. Please, register the value.");
 
-            var mySqlConnectionBuilder = new MySqlConnectionStringBuilder(_connectionProviderOptions.Value.ConnectionString)
-            {
-                Password = string.IsNullOrEmpty(_connectionProviderOptions.Value?.Password)
-                                                    ? string.Empty
-                                                    : _encryptionHelper.TryDecryptAES256(_connectionProviderOptions.Value.Password),
-                UserID = string.IsNullOrEmpty(_connectionProviderOptions.Value?.Username)
-                                                    ? string.Empty
-                                                    : _connectionProviderOptions.Value.Username
-            };
+            var connectionString = _connectionProviderOptions.Value.ConnectionString;
+            var username = _connectionProviderOptions.Value?.Username;
+            var password = _connectionProviderOptions.Value?.Password;
 
-            return new MySqlConnection(mySqlConnectionBuilder.ToString());
+            // if both a username and password were provided, update the connection string with them
+            // otherwise, leave the connection string that was configured alone
+            if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
+            {
+                var connectionStringBuilder = new MySqlConnectionStringBuilder
+                {
+                    Password = _encryptionHelper.TryDecryptAES256(password),
+                    UserID = username
+                };
+                connectionString = connectionStringBuilder.ToString();
+            }
+
+            return new MySqlConnection(connectionString);
         }
     }
 }

--- a/src/Identity.Dapper.MySQL/Connections/MySqlConnectionProvider.cs
+++ b/src/Identity.Dapper.MySQL/Connections/MySqlConnectionProvider.cs
@@ -34,7 +34,7 @@ namespace Identity.Dapper.MySQL.Connections
             // otherwise, leave the connection string that was configured alone
             if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
             {
-                var connectionStringBuilder = new MySqlConnectionStringBuilder
+                var connectionStringBuilder = new MySqlConnectionStringBuilder(connectionString)
                 {
                     Password = _encryptionHelper.TryDecryptAES256(password),
                     UserID = username

--- a/src/Identity.Dapper.MySQL/Identity.Dapper.MySQL.csproj
+++ b/src/Identity.Dapper.MySQL/Identity.Dapper.MySQL.csproj
@@ -14,11 +14,11 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>0.9.3-alpha</Version>
+    <Version>0.9.4-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://github.com/grandchamp/Identity.Dapper/blob/master/LICENSE</PackageLicenseUrl>
-    <AssemblyVersion>0.9.3.0</AssemblyVersion>
-    <FileVersion>0.9.3.0</FileVersion>
+    <AssemblyVersion>0.9.4.0</AssemblyVersion>
+    <FileVersion>0.9.4.0</FileVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Identity.Dapper.PostgreSQL/Connections/PostgreSqlConnectionProvider.cs
+++ b/src/Identity.Dapper.PostgreSQL/Connections/PostgreSqlConnectionProvider.cs
@@ -34,7 +34,7 @@ namespace Identity.Dapper.PostgreSQL.Connections
             // otherwise, leave the connection string that was configured alone
             if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
             {
-                var connectionStringBuilder = new NpgsqlConnectionStringBuilder
+                var connectionStringBuilder = new NpgsqlConnectionStringBuilder(connectionString)
                 {
                     Password = _encryptionHelper.TryDecryptAES256(password),
                     Username = username

--- a/src/Identity.Dapper.PostgreSQL/Connections/PostgreSqlConnectionProvider.cs
+++ b/src/Identity.Dapper.PostgreSQL/Connections/PostgreSqlConnectionProvider.cs
@@ -26,17 +26,23 @@ namespace Identity.Dapper.PostgreSQL.Connections
             if (string.IsNullOrEmpty(_connectionProviderOptions.Value?.ConnectionString))
                 throw new ArgumentNullException("There's no DapperIdentity:ConnectionString configured. Please, register the value.");
 
-            var pSqlConnectionBuilder = new NpgsqlConnectionStringBuilder(_connectionProviderOptions.Value.ConnectionString)
-            {
-                Password = string.IsNullOrEmpty(_connectionProviderOptions.Value?.Password)
-                                                    ? string.Empty
-                                                    : _encryptionHelper.TryDecryptAES256(_connectionProviderOptions.Value.Password),
-                Username = string.IsNullOrEmpty(_connectionProviderOptions.Value?.Username)
-                                                    ? string.Empty
-                                                    : _connectionProviderOptions.Value.Username
-            };
+            var connectionString = _connectionProviderOptions.Value.ConnectionString;
+            var username = _connectionProviderOptions.Value?.Username;
+            var password = _connectionProviderOptions.Value?.Password;
 
-            return new NpgsqlConnection(pSqlConnectionBuilder.ToString());
+            // if both a username and password were provided, update the connection string with them
+            // otherwise, leave the connection string that was configured alone
+            if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password))
+            {
+                var connectionStringBuilder = new NpgsqlConnectionStringBuilder
+                {
+                    Password = _encryptionHelper.TryDecryptAES256(password),
+                    Username = username
+                };
+                connectionString = connectionStringBuilder.ToString();
+            }
+
+            return new NpgsqlConnection(connectionString);
         }
     }
 }

--- a/src/Identity.Dapper.PostgreSQL/Identity.Dapper.PostgreSQL.csproj
+++ b/src/Identity.Dapper.PostgreSQL/Identity.Dapper.PostgreSQL.csproj
@@ -14,10 +14,10 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>0.8.3-alpha</Version>
+    <Version>0.8.4-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://github.com/grandchamp/Identity.Dapper/blob/master/LICENSE</PackageLicenseUrl>
-    <AssemblyVersion>0.8.2.0</AssemblyVersion>
+    <AssemblyVersion>0.8.4.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/src/Identity.Dapper.SqlServer/Connections/SqlServerConnectionProvider.cs
+++ b/src/Identity.Dapper.SqlServer/Connections/SqlServerConnectionProvider.cs
@@ -26,17 +26,22 @@ namespace Identity.Dapper.SqlServer.Connections
             if (string.IsNullOrEmpty(_connectionProviderOptions.Value?.ConnectionString))
                 throw new ArgumentNullException("There's no DapperIdentity:ConnectionString configured. Please, register the value.");
 
-            var sqlConnectionBuilder = new SqlConnectionStringBuilder(_connectionProviderOptions.Value.ConnectionString)
-            {
-                Password = string.IsNullOrEmpty(_connectionProviderOptions.Value?.Password)
-                                                   ? string.Empty
-                                                   : _encryptionHelper.TryDecryptAES256(_connectionProviderOptions.Value.Password),
-                UserID = string.IsNullOrEmpty(_connectionProviderOptions.Value?.Username)
-                                                   ? string.Empty
-                                                   : _connectionProviderOptions.Value.Username
-            };
+            var connectionString = _connectionProviderOptions.Value.ConnectionString;
+            var username = _connectionProviderOptions.Value?.Username;
+            var password = _connectionProviderOptions.Value?.Password;
 
-            return new SqlConnection(sqlConnectionBuilder.ToString());
+            // if both a username and password were provided, update the connection string with them
+            // otherwise, leave the connection string that was configured alone
+            if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password)) {
+                var connectionStringBuilder = new SqlConnectionStringBuilder
+                {
+                    Password = _encryptionHelper.TryDecryptAES256(password),
+                    UserID = username
+                };
+                connectionString = connectionStringBuilder.ToString();
+            }
+
+            return new SqlConnection(connectionString);
         }
     }
 }

--- a/src/Identity.Dapper.SqlServer/Connections/SqlServerConnectionProvider.cs
+++ b/src/Identity.Dapper.SqlServer/Connections/SqlServerConnectionProvider.cs
@@ -33,7 +33,7 @@ namespace Identity.Dapper.SqlServer.Connections
             // if both a username and password were provided, update the connection string with them
             // otherwise, leave the connection string that was configured alone
             if (!string.IsNullOrEmpty(username) && !string.IsNullOrEmpty(password)) {
-                var connectionStringBuilder = new SqlConnectionStringBuilder
+                var connectionStringBuilder = new SqlConnectionStringBuilder(connectionString)
                 {
                     Password = _encryptionHelper.TryDecryptAES256(password),
                     UserID = username

--- a/src/Identity.Dapper.SqlServer/Identity.Dapper.SqlServer.csproj
+++ b/src/Identity.Dapper.SqlServer/Identity.Dapper.SqlServer.csproj
@@ -14,9 +14,10 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>0.8.2-alpha</Version>
+    <Version>0.8.3-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <PackageLicenseUrl>https://github.com/grandchamp/Identity.Dapper/blob/master/LICENSE</PackageLicenseUrl>
+    <AssemblyVersion>0.8.3.0</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">

--- a/test/Identity.Dapper.Tests/ConnectionProviders/MySqlTest.cs
+++ b/test/Identity.Dapper.Tests/ConnectionProviders/MySqlTest.cs
@@ -1,0 +1,97 @@
+﻿using Identity.Dapper.Cryptography;
+using Identity.Dapper.Models;
+using Identity.Dapper.MySQL.Connections;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Identity.Dapper.Tests.ConnectionProviders
+{
+    public class MySqlConnectionProviderTest
+    {
+        private readonly string _key = "E546C8DF278CD5931069B522E695D4F2";  // 32 bytes key for AES256
+        private readonly string _iv = "SomeReallyCoolIV";                   // 16 bytes vector for AES256
+
+        private readonly Mock<ILogger<EncryptionHelper>> _mockLogger;
+        private readonly Mock<IOptions<AESKeys>> _mockKeys;
+        private readonly EncryptionHelper _encryptionHelper;
+
+        public MySqlConnectionProviderTest()
+        {
+            _mockLogger = new Mock<ILogger<EncryptionHelper>>();
+            _mockKeys = new Mock<IOptions<AESKeys>>();
+
+            var aesKeys = new AESKeys
+            {
+                Key = EncryptionHelper.Base64Encode(_key),
+                IV = EncryptionHelper.Base64Encode(_iv)
+            };
+            _mockKeys.Setup(x => x.Value).Returns(aesKeys);
+            _encryptionHelper = new EncryptionHelper(_mockKeys.Object, _mockLogger.Object);
+        }
+
+        [Fact]
+        public void WithUnencryptedCredentials()
+        {
+            var connectionString = "Server=myServerAddress;Database=myDataBase;User Id=xxxx;Password=xxxx";
+            var options = new ConnectionProviderOptions
+            {
+                ConnectionString = connectionString,
+                Username = "testUsername",
+                Password = "testPassword"
+            };
+            var mock = new Mock<IOptions<ConnectionProviderOptions>>();
+            mock.Setup(x => x.Value).Returns(options);
+            var connectionProvider = new MySqlConnectionProvider(mock.Object, _encryptionHelper);
+
+            var connection = connectionProvider.Create();
+            var expected = "Server=myServerAddress;Database=myDataBase;User Id=testUsername;Password=testPassword";
+
+            // connection string should have username/password substituded in
+            Assert.Equal(connection.ConnectionString, expected);
+        }
+
+        [Fact]
+        public void WithEncryptedCredentials()
+        {
+            var connectionString = "Server=myServerAddress;Database=myDataBase;User Id=xxxx;Password=xxxx";
+            var options = new ConnectionProviderOptions
+            {
+                ConnectionString = connectionString,
+                Username = "testUsername",
+                Password = "U29tZVJlYWxseUNvb2xJVqkPdV+l1d6/7cks09hR9PY="
+            };
+            var mock = new Mock<IOptions<ConnectionProviderOptions>>();
+            mock.Setup(x => x.Value).Returns(options);
+            var connectionProvider = new MySqlConnectionProvider(mock.Object, _encryptionHelper);
+
+            var connection = connectionProvider.Create();
+            var expected = "Server=myServerAddress;Database=myDataBase;User Id=testUsername;Password=testPassword";
+
+            // connection string should have username/password substituded in
+            Assert.Equal(connection.ConnectionString, expected);
+        }
+
+        [Fact]
+        public void WithoutCredentials()
+        {
+            var connectionString = "Server=myServerAddress;Database=myDataBase;User Id=xxxx;Password=xxxx";
+            var options = new ConnectionProviderOptions
+            {
+                ConnectionString = connectionString,
+                Username = "",
+                Password = ""
+            };
+            var mock = new Mock<IOptions<ConnectionProviderOptions>>();
+            mock.Setup(x => x.Value).Returns(options);
+            var connectionProvider = new MySqlConnectionProvider(mock.Object, _encryptionHelper);
+
+            var connection = connectionProvider.Create();
+
+            // connection string should be unchanged
+            Assert.Equal(connection.ConnectionString, connectionString);
+        }
+
+    }
+}

--- a/test/Identity.Dapper.Tests/ConnectionProviders/PostgreSqlTest.cs
+++ b/test/Identity.Dapper.Tests/ConnectionProviders/PostgreSqlTest.cs
@@ -1,0 +1,97 @@
+﻿using Identity.Dapper.Cryptography;
+using Identity.Dapper.Models;
+using Identity.Dapper.PostgreSQL.Connections;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Identity.Dapper.Tests.ConnectionProviders
+{
+    public class PostgreSqlConnectionProviderTest
+    {
+        private readonly string _key = "E546C8DF278CD5931069B522E695D4F2";  // 32 bytes key for AES256
+        private readonly string _iv = "SomeReallyCoolIV";                   // 16 bytes vector for AES256
+
+        private readonly Mock<ILogger<EncryptionHelper>> _mockLogger;
+        private readonly Mock<IOptions<AESKeys>> _mockKeys;
+        private readonly EncryptionHelper _encryptionHelper;
+
+        public PostgreSqlConnectionProviderTest()
+        {
+            _mockLogger = new Mock<ILogger<EncryptionHelper>>();
+            _mockKeys = new Mock<IOptions<AESKeys>>();
+
+            var aesKeys = new AESKeys
+            {
+                Key = EncryptionHelper.Base64Encode(_key),
+                IV = EncryptionHelper.Base64Encode(_iv)
+            };
+            _mockKeys.Setup(x => x.Value).Returns(aesKeys);
+            _encryptionHelper = new EncryptionHelper(_mockKeys.Object, _mockLogger.Object);
+        }
+
+        [Fact]
+        public void WithUnencryptedCredentials()
+        {
+            var connectionString = "Host=myServerName;Port=5432;Database=myDataBase;Username=xxxx;Password=xxxx";
+            var options = new ConnectionProviderOptions
+            {
+                ConnectionString = connectionString,
+                Username = "testUsername",
+                Password = "testPassword"
+            };
+            var mock = new Mock<IOptions<ConnectionProviderOptions>>();
+            mock.Setup(x => x.Value).Returns(options);
+            var connectionProvider = new PostgreSqlConnectionProvider(mock.Object, _encryptionHelper);
+
+            var connection = connectionProvider.Create();
+            var expected = "Host=myServerName;Port=5432;Database=myDataBase;Username=testUsername;Password=testPassword";
+
+            // connection string should have username/password substituded in
+            Assert.Equal(connection.ConnectionString, expected);
+        }
+
+        [Fact]
+        public void WithEncryptedCredentials()
+        {
+            var connectionString = "Host=myServerName;Port=5432;Database=myDataBase;Username=xxxx;Password=xxxx";
+            var options = new ConnectionProviderOptions
+            {
+                ConnectionString = connectionString,
+                Username = "testUsername",
+                Password = "U29tZVJlYWxseUNvb2xJVqkPdV+l1d6/7cks09hR9PY="
+            };
+            var mock = new Mock<IOptions<ConnectionProviderOptions>>();
+            mock.Setup(x => x.Value).Returns(options);
+            var connectionProvider = new PostgreSqlConnectionProvider(mock.Object, _encryptionHelper);
+
+            var connection = connectionProvider.Create();
+            var expected = "Host=myServerName;Port=5432;Database=myDataBase;Username=testUsername;Password=testPassword";
+
+            // connection string should have username/password substituded in
+            Assert.Equal(connection.ConnectionString, expected);
+        }
+
+        [Fact]
+        public void WithoutCredentials()
+        {
+            var connectionString = "Host=myServerName;Port=5432;Database=myDataBase;Username=xxxx;Password=xxxx";
+            var options = new ConnectionProviderOptions
+            {
+                ConnectionString = connectionString,
+                Username = "",
+                Password = ""
+            };
+            var mock = new Mock<IOptions<ConnectionProviderOptions>>();
+            mock.Setup(x => x.Value).Returns(options);
+            var connectionProvider = new PostgreSqlConnectionProvider(mock.Object, _encryptionHelper);
+
+            var connection = connectionProvider.Create();
+
+            // connection string should be unchanged
+            Assert.Equal(connection.ConnectionString, connectionString);
+        }
+
+    }
+}

--- a/test/Identity.Dapper.Tests/ConnectionProviders/SqlServerTest.cs
+++ b/test/Identity.Dapper.Tests/ConnectionProviders/SqlServerTest.cs
@@ -1,0 +1,97 @@
+﻿using Identity.Dapper.Cryptography;
+using Identity.Dapper.Models;
+using Identity.Dapper.SqlServer.Connections;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Identity.Dapper.Tests.ConnectionProviders
+{
+    public class SqlServerConnectionProviderTest
+    {
+        private readonly string _key = "E546C8DF278CD5931069B522E695D4F2";  // 32 bytes key for AES256
+        private readonly string _iv = "SomeReallyCoolIV";                   // 16 bytes vector for AES256
+
+        private readonly Mock<ILogger<EncryptionHelper>> _mockLogger;
+        private readonly Mock<IOptions<AESKeys>> _mockKeys;
+        private readonly EncryptionHelper _encryptionHelper;
+
+        public SqlServerConnectionProviderTest()
+        {
+            _mockLogger = new Mock<ILogger<EncryptionHelper>>();
+            _mockKeys = new Mock<IOptions<AESKeys>>();
+
+            var aesKeys = new AESKeys
+            {
+                Key = EncryptionHelper.Base64Encode(_key),
+                IV = EncryptionHelper.Base64Encode(_iv)
+            };
+            _mockKeys.Setup(x => x.Value).Returns(aesKeys);
+            _encryptionHelper = new EncryptionHelper(_mockKeys.Object, _mockLogger.Object);
+        }
+
+        [Fact]
+        public void WithUnencryptedCredentials()
+        {
+            var connectionString = "Data Source=myServerName;Initial Catalog=myDataBase;User ID=xxxx;Password=xxxx";
+            var options = new ConnectionProviderOptions
+            {
+                ConnectionString = connectionString,
+                Username = "testUsername",
+                Password = "testPassword"
+            };
+            var mock = new Mock<IOptions<ConnectionProviderOptions>>();
+            mock.Setup(x => x.Value).Returns(options);
+            var connectionProvider = new SqlServerConnectionProvider(mock.Object, _encryptionHelper);
+
+            var connection = connectionProvider.Create();
+            var expected = "Data Source=myServerName;Initial Catalog=myDataBase;User ID=testUsername;Password=testPassword";
+
+            // connection string should have username/password substituded in
+            Assert.Equal(connection.ConnectionString, expected);
+        }
+
+        [Fact]
+        public void WithEncryptedCredentials()
+        {
+            var connectionString = "Data Source=myServerName;Initial Catalog=myDataBase;User ID=xxxx;Password=xxxx";
+            var options = new ConnectionProviderOptions
+            {
+                ConnectionString = connectionString,
+                Username = "testUsername",
+                Password = "U29tZVJlYWxseUNvb2xJVqkPdV+l1d6/7cks09hR9PY="
+            };
+            var mock = new Mock<IOptions<ConnectionProviderOptions>>();
+            mock.Setup(x => x.Value).Returns(options);
+            var connectionProvider = new SqlServerConnectionProvider(mock.Object, _encryptionHelper);
+
+            var connection = connectionProvider.Create();
+            var expected = "Data Source=myServerName;Initial Catalog=myDataBase;User ID=testUsername;Password=testPassword";
+
+            // connection string should have username/password substituded in
+            Assert.Equal(connection.ConnectionString, expected);
+        }
+
+        [Fact]
+        public void WithoutCredentials()
+        {
+            var connectionString = "Data Source=myServerName;Initial Catalog=myDataBase;User ID=xxxx;Password=xxxx";
+            var options = new ConnectionProviderOptions
+            {
+                ConnectionString = connectionString,
+                Username = "",
+                Password = ""
+            };
+            var mock = new Mock<IOptions<ConnectionProviderOptions>>();
+            mock.Setup(x => x.Value).Returns(options);
+            var connectionProvider = new SqlServerConnectionProvider(mock.Object, _encryptionHelper);
+
+            var connection = connectionProvider.Create();
+
+            // connection string should be unchanged
+            Assert.Equal(connection.ConnectionString, connectionString);
+        }
+
+    }
+}


### PR DESCRIPTION
This addresses issue #78.  

Now, if no username/password is provided, either because they were blank or because ConnectionStrings:DefaultConnection is being used, the connection string configured is left alone.

This also adds unit tests for the three supported connection providers to validate the above changes.