### PR TITLE
Use typeconverter

### DIFF
--- a/src/Identity.Dapper/Identity.Dapper.csproj
+++ b/src/Identity.Dapper/Identity.Dapper.csproj
@@ -14,7 +14,7 @@
     <GenerateAssemblyConfigurationAttribute>false</GenerateAssemblyConfigurationAttribute>
     <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
     <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
-    <Version>0.8.3-alpha</Version>
+    <Version>0.8.4-alpha</Version>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
 

--- a/src/Identity.Dapper/Stores/DapperUserStore.cs
+++ b/src/Identity.Dapper/Stores/DapperUserStore.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Logging;
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data.Common;
 using System.Linq;
 using System.Security.Claims;
@@ -234,7 +235,19 @@ namespace Identity.Dapper.Stores
 
             try
             {
-                var result = await _userRepository.GetByIdAsync((TKey)Convert.ChangeType(userId, typeof(TKey)));
+                TKey key;
+
+                var converter = TypeDescriptor.GetConverter(typeof(TKey));
+                if (converter != null && converter.CanConvertTo(typeof(TKey)) && converter.CanConvertFrom(typeof(string)))
+                {
+                    key = (TKey)converter.ConvertFromInvariantString(userId);
+                }
+                else
+                {
+                    key = (TKey)Convert.ChangeType(userId, typeof(TKey));
+                }
+
+                var result = await _userRepository.GetByIdAsync(key);
 
                 return result;
             }

--- a/src/Identity.Dapper/Stores/DapperUserStore.cs
+++ b/src/Identity.Dapper/Stores/DapperUserStore.cs
@@ -224,6 +224,7 @@ namespace Identity.Dapper.Stores
 
                 return null;
             }
+
         }
 
         public async Task<TUser> FindByIdAsync(string userId, CancellationToken cancellationToken)
@@ -235,10 +236,10 @@ namespace Identity.Dapper.Stores
 
             try
             {
-                TKey key;
+                var key = default(TKey);
 
                 var converter = TypeDescriptor.GetConverter(typeof(TKey));
-                if (converter != null && converter.CanConvertTo(typeof(TKey)) && converter.CanConvertFrom(typeof(string)))
+                if (converter != null && converter.CanConvertFrom(typeof(string)))
                 {
                     key = (TKey)converter.ConvertFromInvariantString(userId);
                 }


### PR DESCRIPTION
When using a key type of Guid with Identity.Dapper, `UserManager.FindByIdAsync` does not work because  `Convert.ChangeType` can't convert a string to a Guid.

This pull request adds support for TypeConverters (for which there are many built in, including for Guid).  If a valid TypeConverter is not found, it falls back on the existing `Convert.ChangeType` call.