### PR TITLE
Bump MySqlConnector from 0.49.3 to 1.0.1

### DIFF
--- a/src/Identity.Dapper.MySQL/Connections/MySqlConnectionProvider.cs
+++ b/src/Identity.Dapper.MySQL/Connections/MySqlConnectionProvider.cs
@@ -2,7 +2,7 @@
 using Identity.Dapper.Cryptography;
 using Identity.Dapper.Models;
 using Microsoft.Extensions.Options;
-using MySql.Data.MySqlClient;
+using MySqlConnector;
 using System;
 using System.Data.Common;
 

--- a/src/Identity.Dapper.MySQL/Identity.Dapper.MySQL.csproj
+++ b/src/Identity.Dapper.MySQL/Identity.Dapper.MySQL.csproj
@@ -27,7 +27,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="MySqlConnector" Version="0.49.3" />
+    <PackageReference Include="MySqlConnector" Version="1.0.1" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
This PR upgrades MySqlConnector to the latest release past 1.0.0. This is significant because version 1.0.0 introduced a breaking change as it changed the namespace.

It's not possible to upgrade MySqlConnector past 0.69.8 (the last version prior to 1.0.0) in a project that's dependent on Identity.Dapper.